### PR TITLE
remove mysql_install_db to allow custom my.cnf to be added first

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,15 @@ MAINTAINER ilari.makela@wunderkraut.com
 # Update the package repository and install applications
 RUN apk --no-cache --update add mariadb && \
     rm -rf /tmp/* && \
-    rm -rf /var/cache/apk/* && \
-    mysql_install_db && \
-    chown -R mysql:mysql /var/lib/mysql
+    rm -rf /var/cache/apk/*
+
+# You will want to install a db before using this image:
+#
+# @note this step is not included in this image as you may want
+#  to first add your own my.cnf before creating the db structure
+##
+#RUN mysql_install_db && \
+#    chown -R mysql:mysql /var/lib/mysql
 
 VOLUME /var/log/mysql
 


### PR DESCRIPTION
See https://github.com/wunderkraut/alpine-mariadb/issues/3

This patch removes (comments) our the RUN mysql_install_db, so that children images can add a custom my.cnf before the db structures are created.
